### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,6 +7,7 @@
   "depends" : [ "XML", "XML::XPath", "Test::META" ],
   "description" : "XML::Rabbit builds your Attributes from xml files with xpath expressions",
   "name" : "XML::Rabbit",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "XML::Rabbit" : "lib/XML/Rabbit.pm6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license